### PR TITLE
Switch to deck by default and add advanced mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ This is a web-based version of the classic board game Taboo.  The goal of the ga
 
 The game data (words and forbidden words) is stored in the `cards_extended.json` file with 206 cards.
 
+## Advanced Mode
+
+By default the game uses this pre-generated deck. You can enable advanced mode to generate new cards with an LLM. Provide your API key in the setup form and set the **Advanced Mode** toggle to "On".
+
 ## Live Version
 
 You can play the game here: [Link to your GitHub Pages site]

--- a/index.html
+++ b/index.html
@@ -463,10 +463,10 @@
                     </select>
                 </div>
                 <div>
-                    <label for="cardSource">Card Source:</label>
-                    <select id="cardSource">
-                        <option value="live">Live (OpenAI API)</option>
-                        <option value="deck">Pre-generated Deck</option>
+                    <label for="advancedMode">Advanced Mode (LLM Cards):</label>
+                    <select id="advancedMode">
+                        <option value="false">Off</option>
+                        <option value="true">On</option>
                     </select>
                 </div>
             </div>
@@ -627,7 +627,7 @@
             timerInterval: null,
             secondsLeft: 45,
             difficulty: "regular",
-            cardSource: "deck",
+            advancedMode: false,
             apiKey: "",
             currentCard: null,
             cardsPlayed: [],
@@ -667,6 +667,7 @@
         const startTutorialBtn = document.getElementById("startTutorialBtn");
         const feedbackDisplay = document.getElementById("feedback"); // Get the feedback element
         const enableVoiceSelect = document.getElementById("enableVoice");
+        const advancedModeSelect = document.getElementById("advancedMode");
         const turnSummaryCardHistoryList = document.getElementById("turnSummaryCardHistory").querySelector("ul");
         const handoverCardHistoryList = document.getElementById("handoverCardHistory").querySelector("ul");
 
@@ -763,7 +764,7 @@
             gameState.targetScore = parseInt(document.getElementById("targetScore").value) || 10;
             gameState.turnDuration = parseInt(document.getElementById("turnDuration").value) || 45;
             gameState.difficulty = document.getElementById("difficulty").value;
-            gameState.cardSource = document.getElementById("cardSource").value;
+            gameState.advancedMode = document.getElementById("advancedMode").value === "true";
             gameState.apiKey = document.getElementById("apiKey").value;
             gameState.enableVoiceRecognition = enableVoiceSelect.value === "true";
 
@@ -880,7 +881,7 @@
             loadingCard.classList.remove("hidden");
             cardDisplay.classList.add("hidden");
 
-            if (gameState.cardSource === "live" && gameState.apiKey) {
+            if (gameState.advancedMode && gameState.apiKey) {
                 try {
                     const card = await generateCardWithAPI();
                     gameState.currentCard = card;
@@ -1148,7 +1149,7 @@
                 timerInterval: null,
                 secondsLeft: 45,
                 difficulty: "regular",
-                cardSource: "deck",
+                advancedMode: false,
                 apiKey: "",
                 currentCard: null,
                 cardsPlayed: [],


### PR DESCRIPTION
## Summary
- default to the pre-generated deck instead of the OpenAI API
- add an Advanced Mode toggle that enables API-based card generation
- document the new option in README

## Testing
- `npm test`
- `npm run validate`


------
https://chatgpt.com/codex/tasks/task_e_6854053374d88330809639a6ef6bf93b